### PR TITLE
Fix error in the homepage CMS preview

### DIFF
--- a/static/admin/admin.js
+++ b/static/admin/admin.js
@@ -252,7 +252,7 @@ var HomepagePreview = createClass({
     render: function() {
         const entry = this.props.entry.toJS()
         const data = entry.data
-        let regBtn = h()
+        let regBtn = h('div', {})
         let btns = data.buttons.map(b => h('button',{href:b.href}, b.text))
         if (data.registerButtonEnabled) {
             regBtn = h('button', {className: "reg-button"}, 'Buy a Badge')


### PR DESCRIPTION
Fix an error reported by the CMS when previewing the homepage entry. See [Minified React error #130](https://react.dev/errors/130?args[]=undefined&args[]=)