### PR TITLE
Registration CMS: split "closed" state into "pre-festival" and "post-festival" states

### DIFF
--- a/src/pages/register.js
+++ b/src/pages/register.js
@@ -25,7 +25,7 @@ import { styled, makeStyles } from '@material-ui/styles'
 import { navigate, Link } from 'gatsby'
 import RegistrationTier from '@components/registrationTier'
 import registerInfo from './registerinfo.json'
-const {allBadgeTiers, registrationEnabled, showBadgePricingNote, showBadgePickupHours, badgePickupHoursText, badgePricingHoursText, regClosedHeading, regClosedText } = registerInfo
+const {allBadgeTiers, registrationStatus, showBadgePricingNote, showBadgePickupHours, badgePickupHoursText, badgePricingHoursText, regClosedWaitingHeading, regClosedWaitingText, regClosedHeading, regClosedText } = registerInfo
 
 let lambdaUrl
 
@@ -470,11 +470,29 @@ const ClosedRegisterPage = () => {
   )
 }
 
+const ClosedWaitingRegisterPage = () => {
+  return (
+    <Layout>
+      <Seo title="Register" />
+      <Hero header={regClosedWaitingHeading} />
+      <PageContent>
+        <p dangerouslySetInnerHTML={{__html: regClosedWaitingText}}></p>
+        <NewsletterSignup />
+      </PageContent>
+    </Layout>
+  )
+}
+
 const RegisterPage = () => {
-  if (registrationEnabled) {
+  const isOpen = registrationStatus === "open" // Registration is open
+  const isClosed = registrationStatus === "closed" // Closed post-festival
+  const isWaiting = registrationStatus === "waiting" // Closed pre-festival
+  if (isOpen) {
     return <OpenRegisterPage />
-  } else {
+  } else if (isClosed) {
     return <ClosedRegisterPage />
+  } else if (isWaiting) {
+    return <ClosedWaitingRegisterPage />
   }
 }
 

--- a/src/pages/registerinfo.json
+++ b/src/pages/registerinfo.json
@@ -1,11 +1,13 @@
 {
-  "registrationEnabled": false,
+  "registrationStatus": "waiting",
   "showBadgePickupHours": true,
   "badgePickupHoursText": "Thursday, October 30: 5-7 PM\nFriday, October 31: 10 AM-7 PM\nSaturday, November 1: 9:30 AM-7 PM\nSunday, November 2: 9:30 AM-12 PM ",
   "showBadgePricingNote": false,
   "badgePricingHoursText": "Silver badges decrease in price as the weekend goes on.\n\nFriday (Full Weekend): $90\nSaturday (Saturday + Sunday): $75\nSunday: Unavailable, please purchase a Bronze badge for Sunday!",
-  "regClosedHeading": "Registration for USIF 2026 coming soon!",
-  "regClosedText": "Registration for USIF 2026 will open in the near future. Check back soon, and keep an eye on social media!\n",
+  "regClosedWaitingHeading": "Registration for USIF 2026 coming soon!",
+  "regClosedWaitingText": "Registration for USIF 2026 will open in the near future. Check back soon, and keep an eye on social media!\n",
+  "regClosedHeading": "Thank you for attending U.S IdolFes 2025!",
+  "regClosedText": "Registration is closed because USIF 2025 is now over. Thank you for making our first convention in CA a huge success! Sign up for our email list below to get notified when our next event will be!\n",
   "allBadgeTiers": [
     {
       "badgeName": "Friday",

--- a/src/pages/registerinfo.json
+++ b/src/pages/registerinfo.json
@@ -7,7 +7,7 @@
   "regClosedWaitingHeading": "Registration for USIF 2026 coming soon!",
   "regClosedWaitingText": "Registration for USIF 2026 will open in the near future. Check back soon, and keep an eye on social media!\n",
   "regClosedHeading": "Thank you for attending U.S IdolFes 2025!",
-  "regClosedText": "Registration is closed because USIF 2025 is now over. Thank you for making our first convention in CA a huge success! Sign up for our email list below to get notified when our next event will be!\n",
+  "regClosedText": "Registration is closed because USIF 2025 is now over. Thank you for making our first convention in CA a huge success!\n",
   "allBadgeTiers": [
     {
       "badgeName": "Friday",

--- a/static/admin/admin.js
+++ b/static/admin/admin.js
@@ -206,9 +206,12 @@ CMS.registerPreviewTemplate("hotel", HotelPreview)
 var RegisterPreview = createClass({
     render: function() {
         const data = this.props.entry.toJS().data
+        const isOpen = data.registrationStatus === "open"
+        const isClosed = data.registrationStatus === "closed"
+        const isWaiting = data.registrationStatus === "waiting"
         let regPageItself
         let preStuff
-        if (data.registrationEnabled) {
+        if (isOpen) {
             let prestuff1, prestuff2
             if (data.showBadgePickupHours) {
                 prestuff1 = h('div', {className: "badge-text"}, h('h4', {}, 'Badge Pick-Up Hours'), 
@@ -231,10 +234,15 @@ var RegisterPreview = createClass({
                         h('p', {dangerouslySetInnerHTML: {__html: tier.description}}),
                         h('ul', {}, tier.perks.map(p => h('li', {}, p)))))),
                     h('div', {className: "dummy-container"}, '[ Register Form ]'))
-        } else {
+        } else if (isClosed) {
             regPageItself = h('div', {}, 
                 h('h1', {}, data.regClosedHeading),
                 h('div', {dangerouslySetInnerHTML:{__html: data.regClosedText}}),
+                h('div', {className: "dummy-container"}, '[ Email Subscription Area ]'))
+        } else if (isWaiting) {
+            regPageItself = h('div', {}, 
+                h('h1', {}, data.regClosedWaitingHeading),
+                h('div', {dangerouslySetInnerHTML:{__html: data.regClosedWaitingText}}),
                 h('div', {className: "dummy-container"}, '[ Email Subscription Area ]'))
         }
         return h('div', {}, 

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -143,19 +143,28 @@ collections:
             - {label: "Button Text", name: "text", widget: "string"}
             - {label: "Link URL", name: href, widget: "string" }
         - {label: "Number of event schedule days", name: "scheduleDays", widget: "number"}
+
     - label: "Registration"
       name: "registration"
       file: "src/pages/registerinfo.json"
       extension: "json"
       description: "Enable or disable registration, set badge prices, etc"
       fields: 
-        - {label: "Registration Enabled", name: "registrationEnabled", widget: "boolean"}
+        - label: "Registration Status"
+          name: "registrationStatus"
+          widget: "select"
+          options:
+            - { label: "Open", value: "open" }
+            - { label: "Closed (pre-festival)", value: "waiting" }
+            - { label: "Closed (post-festival)", value: "closed" }
         - {label: "Show Badge Pickup Text", name: "showBadgePickupHours", widget: "boolean"}
         - {label: "Badge Pickup Text (html ok)", name: "badgePickupHoursText", widget: "text"}
         - {label: "Show Weekend Pricing Text", name: "showBadgePricingNote", widget: "boolean"}
         - {label: "Weekend Pricing Text (html ok)", name: "badgePricingHoursText", widget: "text"}
-        - {label: "Heading to show when registration closed", name: "regClosedHeading", widget: "string"}
-        - {label: "Text to show when registration closed", name: "regClosedText", widget: "text"}
+        - {label: "Heading (closed pre-festival)", name: "regClosedWaitingHeading", widget: "string"}
+        - {label: "Text (closed pre-festival)", name: "regClosedWaitingText", widget: "text"}
+        - {label: "Heading (closed post-festival)", name: "regClosedHeading", widget: "string"}
+        - {label: "Text (closed post-festival)", name: "regClosedText", widget: "text"}
 
         - label: Badge Tiers
           name: allBadgeTiers


### PR DESCRIPTION
Add pre-festival and post-festival states for the registration page's CMS entry, allowing admins to easily show different content on the page depending if registration is open, closed but opening soon, or closed.
Previously, one would have to completely overwrite the closed registration page contents before and after the event. This feature makes it a bit more convenient to switch between these two cases.

Create sample text for the closed post-festival content, copying the text as it was at the end of USIF 2025.